### PR TITLE
Update for v3 of config file

### DIFF
--- a/nixos-options.md
+++ b/nixos-options.md
@@ -1,5 +1,7 @@
 ## services\.ngrok\.enable
 
+
+
 Whether to enable ngrok service\.
 
 
@@ -16,6 +18,40 @@ boolean
 
 *Example:*
 ` true `
+
+
+
+## services\.ngrok\.configFileVersion
+
+The version of the ngrok config file\. See [ngrok Agent Configuration File](https://ngrok\.com/docs/agent/config/)\.
+
+
+
+*Type:*
+integer between 2 and 3 (both inclusive)
+
+
+
+*Default:*
+` 3 `
+
+
+
+## services\.ngrok\.endpoints
+
+
+
+This is a list of endpoint definitions\. See [Endpoint Definitions](https://ngrok\.com/docs/agent/config/v3/\#endpoint-definitions) for more details\.
+
+
+
+*Type:*
+list of (attribute set)
+
+
+
+*Default:*
+` [ ] `
 
 
 
@@ -53,6 +89,24 @@ list of string
 
 *Default:*
 ` [ ] `
+
+
+
+## services\.ngrok\.group
+
+
+
+Group which runs the ngrok agent\.
+
+
+
+*Type:*
+string
+
+
+
+*Default:*
+` "ngrok" `
 
 
 
@@ -96,7 +150,7 @@ string
 
 
 
-This is a map of names to tunnel definitions\. See [tunnel-configurations](https://ngrok\.com/docs/agent/config/\#tunnel-configurations) for more details\.
+\[Deprecated: Use endpoints instead] This is a map of names to tunnel definitions\. See [tunnel-configurations](https://ngrok\.com/docs/agent/config/\#tunnel-configurations) for more details\.
 
 
 
@@ -107,5 +161,23 @@ attribute set
 
 *Default:*
 ` { } `
+
+
+
+## services\.ngrok\.user
+
+
+
+User which runs the ngrok agent\.
+
+
+
+*Type:*
+string
+
+
+
+*Default:*
+` "ngrok" `
 
 

--- a/nixos.nix
+++ b/nixos.nix
@@ -89,7 +89,7 @@ in
 
     users.users.${cfg.user} = {
       isSystemUser = true;
-      home = "/var/lib/ngrok";
+      home = "/var/lib/${cfg.user}";
       createHome = true;
       shell = null;
       inherit (cfg) group;
@@ -143,8 +143,8 @@ in
           ExecStart = "${pkgs.ngrok}/bin/ngrok --config ${ngrokConfig} ${extraConfigs} start ${startArg}";
           Restart = "always";
           RestartSec = "15";
-          User = "ngrok";
-          Group = "ngrok";
+          User = cfg.user;
+          Group = cfg.group;
         };
       };
   };

--- a/nixos.nix
+++ b/nixos.nix
@@ -1,4 +1,9 @@
-{ lib, pkgs, config, ... }:
+{
+  lib,
+  pkgs,
+  config,
+  ...
+}:
 with lib;
 with builtins;
 let
@@ -79,62 +84,68 @@ in
       };
     };
   };
-  config = mkIf cfg.enable
-    {
-      users.groups.${cfg.group} = {};
+  config = mkIf cfg.enable {
+    users.groups.${cfg.group} = { };
 
-      users.users.${cfg.user} = {
-        isSystemUser = true;
-        home = "/var/lib/ngrok";
-        createHome = true;
-        shell = null;
-        inherit (cfg) group;
-      };
+    users.users.${cfg.user} = {
+      isSystemUser = true;
+      home = "/var/lib/ngrok";
+      createHome = true;
+      shell = null;
+      inherit (cfg) group;
+    };
 
-      systemd.services.ngrok =
-        let
-          commonConfig = {
-            version = "${toString cfg.configFileVersion}";
+    systemd.services.ngrok =
+      let
+        commonConfig = {
+          version = "${toString cfg.configFileVersion}";
 
-            inherit (cfg) tunnels endpoints;
-          };
+          inherit (cfg) tunnels endpoints;
+        };
 
-          v2Config = commonConfig // {
+        v2Config =
+          commonConfig
+          // {
             inherit (cfg) log_level log_format;
             log = "stdout";
-          } // cfg.extraConfig;
+          }
+          // cfg.extraConfig;
 
-          v3Config = commonConfig // cfg.extraConfig // {
+        v3Config =
+          commonConfig
+          // cfg.extraConfig
+          // {
             agent = {
               inherit (cfg) log_level log_format;
               log = "stdout";
-            } // (cfg.extraConfig.agent or {});
+            } // (cfg.extraConfig.agent or { });
           };
 
-          configFile = if cfg.configFileVersion == 2 then v2Config else v3Config;
+        configFile = if cfg.configFileVersion == 2 then v2Config else v3Config;
 
-          ngrokConfig = pkgs.writeTextFile {
-            name = "ngrok-config";
-            text = toJSON configFile;
-          };
-          startArg = if (length (attrNames cfg.tunnels) > 0 || length cfg.endpoints > 0)  then "--all" else "--none";
-          extraConfigs = concatStringsSep " " (map (file: "--config ${file}") cfg.extraConfigFiles);
-        in
-        {
-          description = "The ngrok agent.";
-          wantedBy = [ "multi-user.target" ];
-          after = [ "network.target" ];
-          unitConfig = {
-            StartLimitInterval = "5s";
-            StartLimitBurst = "10s";
-          };
-          serviceConfig = {
-            ExecStart = "${pkgs.ngrok}/bin/ngrok --config ${ngrokConfig} ${extraConfigs} start ${startArg}";
-            Restart = "always";
-            RestartSec = "15";
-            User = "ngrok";
-            Group = "ngrok";
-          };
+        ngrokConfig = pkgs.writeTextFile {
+          name = "ngrok-config";
+          text = toJSON configFile;
         };
-    };
+        startArg =
+          if (length (attrNames cfg.tunnels) > 0 || length cfg.endpoints > 0) then "--all" else "--none";
+        extraConfigs = concatStringsSep " " (map (file: "--config ${file}") cfg.extraConfigFiles);
+      in
+      {
+        description = "The ngrok agent.";
+        wantedBy = [ "multi-user.target" ];
+        after = [ "network.target" ];
+        unitConfig = {
+          StartLimitInterval = "5s";
+          StartLimitBurst = "10s";
+        };
+        serviceConfig = {
+          ExecStart = "${pkgs.ngrok}/bin/ngrok --config ${ngrokConfig} ${extraConfigs} start ${startArg}";
+          Restart = "always";
+          RestartSec = "15";
+          User = "ngrok";
+          Group = "ngrok";
+        };
+      };
+  };
 }

--- a/nixos.nix
+++ b/nixos.nix
@@ -13,7 +13,15 @@ in
         type = with types; attrs;
         default = { };
         description = ''
-          This is a map of names to tunnel definitions. See [tunnel-configurations](https://ngrok.com/docs/agent/config/#tunnel-configurations) for more details.
+          [Deprecated: Use endpoints instead] This is a map of names to tunnel definitions. See [tunnel-configurations](https://ngrok.com/docs/agent/config/#tunnel-configurations) for more details.
+        '';
+      };
+
+      endpoints = mkOption {
+        type = types.listOf types.attrs;
+        default = [ ];
+        description = ''
+          This is a list of endpoint definitions. See [Endpoint Definitions](https://ngrok.com/docs/agent/config/v3/#endpoint-definitions) for more details.
         '';
       };
 
@@ -33,6 +41,14 @@ in
         '';
       };
 
+      configFileVersion = mkOption {
+        type = types.ints.between 2 3;
+        default = 3;
+        description = ''
+          The version of the ngrok config file. See [ngrok Agent Configuration File](https://ngrok.com/docs/agent/config/).
+        '';
+      };
+
       extraConfig = mkOption {
         type = with types; attrs;
         default = { };
@@ -49,32 +65,59 @@ in
           Use this for sensitive configuration that shouldn't go into the nixos configuration and nix store.
         '';
       };
+
+      user = mkOption {
+        type = types.str;
+        default = "ngrok";
+        description = "User which runs the ngrok agent.";
+      };
+
+      group = mkOption {
+        type = types.str;
+        default = "ngrok";
+        description = "Group which runs the ngrok agent.";
+      };
     };
   };
   config = mkIf cfg.enable
     {
-      users.groups = {
-        ngrok = { };
-      };
-      users.users.ngrok = {
+      users.groups.${cfg.group} = {};
+
+      users.users.${cfg.user} = {
         isSystemUser = true;
         home = "/var/lib/ngrok";
         createHome = true;
         shell = null;
-        group = "ngrok";
+        inherit (cfg) group;
       };
+
       systemd.services.ngrok =
         let
+          commonConfig = {
+            version = "${toString cfg.configFileVersion}";
+
+            inherit (cfg) tunnels endpoints;
+          };
+
+          v2Config = commonConfig // {
+            inherit (cfg) log_level log_format;
+            log = "stdout";
+          } // cfg.extraConfig;
+
+          v3Config = commonConfig // cfg.extraConfig // {
+            agent = {
+              inherit (cfg) log_level log_format;
+              log = "stdout";
+            } // (cfg.extraConfig.agent or {});
+          };
+
+          configFile = if cfg.configFileVersion == 2 then v2Config else v3Config;
+
           ngrokConfig = pkgs.writeTextFile {
             name = "ngrok-config";
-            text = toJSON
-              ({
-                inherit (cfg) tunnels log_level log_format;
-                version = "2";
-                log = "stdout";
-              } // cfg.extraConfig);
+            text = toJSON configFile;
           };
-          startArg = if length (attrNames cfg.tunnels) > 0 then "--all" else "--none";
+          startArg = if (length (attrNames cfg.tunnels) > 0 || length cfg.endpoints > 0)  then "--all" else "--none";
           extraConfigs = concatStringsSep " " (map (file: "--config ${file}") cfg.extraConfigFiles);
         in
         {


### PR DESCRIPTION
Closes #6 

### Why

This adds support for [Agent Config Version 3](https://ngrok.com/docs/agent/config/v3/).

### How

I couldn't find a more elegant way of doing this, since v3 also supports tunnels(even though they are deprecated). What seemed like the best solution was allow users to set the `configFileVersion` and have it default to `3`. Also allows for specifying endpoints like so.

### Testing

```nix
services.ngrok = {
  enable = true;
  user = "ngrokd";
  group = "ngrok";
  endpoints = [
    {
      name = "httpbin";
      url = "<redacted>-httpbin.ngrok.app";
      upstream = {
        url = 8080;
      };
    }
  ];
  extraConfig = {
    agent = {
      authtoken = "<redacted>";
    };
  };
};

```